### PR TITLE
docs(skills): clarify h3-prompt-writing is agent-portable, not OpenAI-only

### DIFF
--- a/.agents/skills/h3-prompt-writing/SKILL.md
+++ b/.agents/skills/h3-prompt-writing/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: h3-prompt-writing
 description: Write MiniMax H3 video generation prompts for T2VA, I2VA, FL2VA, L2VA, and Ref2VA. Use when rewriting multimodal requests into H3 prompt structures, composing integrated_multimodal_description, overall_soundscape, and non_diegetic_music, aligning keyframes, or defining reference labels for images, videos, and audio.
+compatibility: Portable to any agent that can read local files — no external API calls, MiniMax Hub tools, or proprietary runtime required. The agents/openai.yaml file only adds optional ChatGPT/Codex UI metadata; it does not restrict the skill to OpenAI agents.
 ---
 
 # H3 Prompt Writing

--- a/.claude/skills/h3-prompt-writing/SKILL.md
+++ b/.claude/skills/h3-prompt-writing/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: h3-prompt-writing
 description: Write MiniMax H3 video generation prompts for T2VA, I2VA, FL2VA, L2VA, and Ref2VA. Use when rewriting multimodal requests into H3 prompt structures, composing integrated_multimodal_description, overall_soundscape, and non_diegetic_music, aligning keyframes, or defining reference labels for images, videos, and audio.
+compatibility: Portable to any agent that can read local files — no external API calls, MiniMax Hub tools, or proprietary runtime required. The agents/openai.yaml file only adds optional ChatGPT/Codex UI metadata; it does not restrict the skill to OpenAI agents.
 ---
 
 # H3 Prompt Writing

--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ Install the H3 prompt writing skill — one of nine skills bundled with this rep
 npx skills add https://github.com/MiniMax-AI/MiniMax-H3 --skill h3-prompt-writing
 ```
 
-It ships with two prompt guides under `skills/h3-prompt-writing/references/`: `base-en.txt` for text/keyframe modes and `ref-en.txt` for full-reference (Ref2VA) mode. The remaining eight are style-specific video generation skills:
+It ships with two prompt guides under `skills/h3-prompt-writing/references/`: `base-en.txt` for text/keyframe modes and `ref-en.txt` for full-reference (Ref2VA) mode.
+
+**Agent compatibility:** `h3-prompt-writing` is a plain Markdown + reference-file skill with no external API calls, so it works in Claude Code, the Claude Agent SDK, Cursor, Windsurf, OpenAI-based agents/Codex, LangChain, or any other harness that can read a `SKILL.md` and local files. The bundled `skills/h3-prompt-writing/agents/openai.yaml` only adds optional UI metadata (display name, description, default prompt) for the ChatGPT/Codex skills UI, per [OpenAI's skill spec](https://learn.chatgpt.com/docs/build-skills) — it does not limit the skill to OpenAI agents.
+
+The remaining eight are style-specific video generation skills built for the MiniMax Hub's canvas workflow (`hub_generate_video`, `hub_generate_image`, canvas nodes, choice cards, etc.) and are not portable to generic agent harnesses:
 
 <table align="center">
   <tr>

--- a/skills/h3-prompt-writing/SKILL.md
+++ b/skills/h3-prompt-writing/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: h3-prompt-writing
 description: Write MiniMax H3 video generation prompts for T2VA, I2VA, FL2VA, L2VA, and Ref2VA. Use when rewriting multimodal requests into H3 prompt structures, composing integrated_multimodal_description, overall_soundscape, and non_diegetic_music, aligning keyframes, or defining reference labels for images, videos, and audio.
+compatibility: Portable to any agent that can read local files — no external API calls, MiniMax Hub tools, or proprietary runtime required. The agents/openai.yaml file only adds optional ChatGPT/Codex UI metadata; it does not restrict the skill to OpenAI agents.
 ---
 
 # H3 Prompt Writing


### PR DESCRIPTION
## Summary
- Add a `compatibility` field to `h3-prompt-writing/SKILL.md` (mirrored across `skills/`, `.claude/skills/`, and `.agents/skills/`) clarifying the skill works with any agent that can read local files, with no external API calls or MiniMax Hub tools required.
- Add a README note explaining `agents/openai.yaml` only supplies optional ChatGPT/Codex UI metadata (per OpenAI's skill spec) and does not restrict `h3-prompt-writing` to OpenAI agents.
- Document that the other eight skills are MiniMax Hub-native (canvas workflow, `hub_*` tools) and not portable to generic agent harnesses — mirroring the compatibility notes already published in the `awesome-minimax-h3` reference repo.

## Test plan
- [x] Verified `agents/openai.yaml` reflects OpenAI's documented Codex skills UI-override format (checked against learn.chatgpt.com/docs/build-skills) — it is additive, not exclusive.
- [x] Confirmed the three tracked copies of `h3-prompt-writing` (`skills/`, `.claude/skills/`, `.agents/skills/`) remain byte-identical after the edit.
- [x] Docs-only change; no code paths affected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/MiniMax-H3/pr/13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788881299&installation_model_id=427615&pr_number=13&repository=MiniMax-AI%2FMiniMax-H3&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2FMiniMax-H3%2Fpull%2F13&signature=66715d10f6f51b86d2926a4af6c09bdcd27ebfad1bfe64e12ee704cb11ad87c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->