### PR TITLE
Fix init_weights in dac_utils.py for weight_norm Conv1d layers

### DIFF
--- a/FL2VA/audio_vae/dac_utils.py
+++ b/FL2VA/audio_vae/dac_utils.py
@@ -3,9 +3,26 @@
 
 
 def init_weights(m, mean=0.0, std=0.01):
+    """Initialize ``Conv*`` layers, including those wrapped with ``weight_norm``.
+
+    BigVGAN (``dac_bigvgan.py``) wraps every conv in
+    ``torch.nn.utils.parametrizations.weight_norm`` and then calls
+    ``self.convs1.apply(init_weights)`` / ``self.convs2.apply(init_weights)``
+    / ``self.conv_post.apply(init_weights)``. Under the parametrization
+    API, ``m.weight`` is computed on access from ``m.weight_g`` and
+    ``m.weight_v``, so the previous ``m.weight.data.normal_(...)`` was
+    a silent no-op for the stored parameters. Branch on the
+    parametrized attributes to actually update the underlying
+    parameters, matching the legacy ``torch.nn.utils.weight_norm``
+    behaviour that this file historically targeted.
+    """
     classname = m.__class__.__name__
     if classname.find("Conv") != -1:
-        m.weight.data.normal_(mean, std)
+        if hasattr(m, "weight_v") and hasattr(m, "weight_g"):
+            m.weight_v.data.normal_(mean, std)
+            m.weight_g.data.fill_(1.0)
+        else:
+            m.weight.data.normal_(mean, std)
 
 
 def get_padding(kernel_size, dilation=1):

--- a/Ref2VA/audio_vae/dac_utils.py
+++ b/Ref2VA/audio_vae/dac_utils.py
@@ -3,9 +3,26 @@
 
 
 def init_weights(m, mean=0.0, std=0.01):
+    """Initialize ``Conv*`` layers, including those wrapped with ``weight_norm``.
+
+    BigVGAN (``dac_bigvgan.py``) wraps every conv in
+    ``torch.nn.utils.parametrizations.weight_norm`` and then calls
+    ``self.convs1.apply(init_weights)`` / ``self.convs2.apply(init_weights)``
+    / ``self.conv_post.apply(init_weights)``. Under the parametrization
+    API, ``m.weight`` is computed on access from ``m.weight_g`` and
+    ``m.weight_v``, so the previous ``m.weight.data.normal_(...)`` was
+    a silent no-op for the stored parameters. Branch on the
+    parametrized attributes to actually update the underlying
+    parameters, matching the legacy ``torch.nn.utils.weight_norm``
+    behaviour that this file historically targeted.
+    """
     classname = m.__class__.__name__
     if classname.find("Conv") != -1:
-        m.weight.data.normal_(mean, std)
+        if hasattr(m, "weight_v") and hasattr(m, "weight_g"):
+            m.weight_v.data.normal_(mean, std)
+            m.weight_g.data.fill_(1.0)
+        else:
+            m.weight.data.normal_(mean, std)
 
 
 def get_padding(kernel_size, dilation=1):


### PR DESCRIPTION
# Follow-up to #10: fix `init_weights` in `dac_utils.py` for `weight_norm` Conv1d

## What's in this PR

The same `init_weights` bug pattern from #10 exists in a **second**
file in this repo: `FL2VA/audio_vae/dac_utils.py` (duplicated verbatim
under `Ref2VA/`). This PR applies the same fix there, scoped only to
the audio VAE helper so it stays small and reviewable.

## Why

`dac_audio_vae.py` ships its own `init_weights` (the version fixed in
#10), but the **BigVGAN decoder** — the upsampling stack that
actually turns the latent audio into a waveform — uses a *different*
`init_weights` from `dac_utils.py`:

```python
def init_weights(m, mean=0.0, std=0.01):
    classname = m.__class__.__name__
    if classname.find("Conv") != -1:
        m.weight.data.normal_(mean, std)
```

BigVGAN wraps every `Conv1d` in
`torch.nn.utils.parametrizations.weight_norm`, and calls
`init_weights` on three ModuleLists / Modules:

- `dac_bigvgan.py:64` — `self.convs1.apply(init_weights)`
- `dac_bigvgan.py:81` — `self.convs2.apply(init_weights)`
- `dac_bigvgan.py:175` — `self.conv_post.apply(init_weights)`

So **every conv in the BigVGAN decoder** silently stays at its default
initialization under the new `parametrizations.weight_norm` API,
because the in-place `m.weight.data.normal_(...)` writes to a
temporary recomputed tensor. `DacAudioVAE.__init__` does call
`self.apply(...)` after constructing the decoder, so this propagates
into the saved checkpoint when training from scratch.

## Fix

Same pattern as #10 — branch on the parametrized attributes and init
the underlying `weight_v` / `weight_g` directly:

```python
def init_weights(m, mean=0.0, std=0.01):
    """Initialize ``Conv*`` layers, including those wrapped with ``weight_norm``.

    BigVGAN (``dac_bigvgan.py``) wraps every conv in
    ``torch.nn.utils.parametrizations.weight_norm`` and then calls
    ``self.convs1.apply(init_weights)`` / ``self.convs2.apply(init_weights)``
    / ``self.conv_post.apply(init_weights)``. Under the parametrization
    API, ``m.weight`` is computed on access from ``m.weight_g`` and
    ``m.weight_v``, so the previous ``m.weight.data.normal_(...)`` was
    a silent no-op for the stored parameters. Branch on the
    parametrized attributes to actually update the underlying
    parameters, matching the legacy ``torch.nn.utils.weight_norm``
    behaviour that this file historically targeted.
    """
    classname = m.__class__.__name__
    if classname.find("Conv") != -1:
        if hasattr(m, "weight_v") and hasattr(m, "weight_g"):
            m.weight_v.data.normal_(mean, std)
            m.weight_g.data.fill_(1.0)
        else:
            m.weight.data.normal_(mean, std)
```

`dac_utils.py` is duplicated verbatim across `FL2VA/` and `Ref2VA/`,
so the same change is applied to both copies.

## Risk

Identical to #10: gated by `hasattr` on the parametrized attributes.
Plain `Conv*` layers (and the legacy `torch.nn.utils.weight_norm`
path) take the same code path as before. Inference is unchanged
(checkpoint weights are loaded via `load_state_dict`); the fix only
matters when constructing the model from scratch.

## Test plan

- `python -c "import ast; ast.parse(open('FL2VA/audio_vae/dac_utils.py').read())"`
  — passes.
- Loading a `DacAudioVAE` from a checkpoint still produces the same
  state dict as before.
- The companion fix in `dac_audio_vae.py` (#10) is already merged on
  `main`.

## Follow-ups (out of scope for this PR)

- `dac_utils.py` does **not** initialize `bias`. The legacy HiFi-GAN
  code this is adapted from historically didn't either, so this is
  preserving the historical behavior, not a regression — but worth
  noting.
- The class-name match `find("Conv")` matches any class with "Conv"
  in its name (Conv1d, Conv2d, Conv3d, ConvTranspose*, etc.). All
  convolutions in BigVGAN are `Conv1d`, so this is a non-issue in
  practice, but a stricter `isinstance(m, (nn.Conv1d,))` check
  would be more defensive.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/MiniMax-H3/pr/14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788885332&installation_model_id=427615&pr_number=14&repository=MiniMax-AI%2FMiniMax-H3&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2FMiniMax-H3%2Fpull%2F14&signature=36fb6b748bae7a5e14e590141df9ed994fc57befc181afb6b12f73d55b7b8f58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->