### PR TITLE
docs(skills): add compatibility fields to Hub-native skills, sync i18n READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -32,7 +32,11 @@
 npx skills add https://github.com/MiniMax-AI/MiniMax-H3 --skill h3-prompt-writing
 ```
 
-このスキルには `skills/h3-prompt-writing/references/` 配下に 2 つのプロンプトガイドが含まれています。`base-en.txt` はテキスト/キーフレームモード用、`ref-en.txt` はフルリファレンス（Ref2VA）モード用です。残りの 8 つはスタイル別の動画生成スキルです:
+このスキルには `skills/h3-prompt-writing/references/` 配下に 2 つのプロンプトガイドが含まれています。`base-en.txt` はテキスト/キーフレームモード用、`ref-en.txt` はフルリファレンス（Ref2VA）モード用です。
+
+**エージェント互換性：** `h3-prompt-writing` は外部 API 呼び出しを行わない、純粋な Markdown + リファレンスファイルのスキルです。そのため、Claude Code、Claude Agent SDK、Cursor、Windsurf、OpenAI ベースのエージェント/Codex、LangChain など、`SKILL.md` とローカルファイルを読み取れるあらゆる環境で動作します。同梱されている `skills/h3-prompt-writing/agents/openai.yaml` は、[OpenAI のスキル仕様](https://learn.chatgpt.com/docs/build-skills) に基づき、ChatGPT/Codex のスキル UI 向けに任意の UI メタデータ（表示名、説明、デフォルトプロンプト）を追加するだけであり、このスキルを OpenAI エージェント専用に制限するものではありません。
+
+残りの 8 つは、MiniMax Hub のキャンバスワークフロー（`hub_generate_video`、`hub_generate_image`、キャンバスノード、選択カードなど）向けに構築されたスタイル別の動画生成スキルであり、汎用のエージェント実行環境には移植できません:
 
 <table align="center">
   <tr>

--- a/README.ko.md
+++ b/README.ko.md
@@ -32,7 +32,11 @@
 npx skills add https://github.com/MiniMax-AI/MiniMax-H3 --skill h3-prompt-writing
 ```
 
-이 스킬은 `skills/h3-prompt-writing/references/` 아래에 두 개의 프롬프트 가이드를 제공합니다. `base-en.txt`는 텍스트/키프레임 모드용이고, `ref-en.txt`는 전체 참조(Ref2VA) 모드용입니다. 나머지 여덟 개는 스타일별 비디오 생성 스킬입니다:
+이 스킬은 `skills/h3-prompt-writing/references/` 아래에 두 개의 프롬프트 가이드를 제공합니다. `base-en.txt`는 텍스트/키프레임 모드용이고, `ref-en.txt`는 전체 참조(Ref2VA) 모드용입니다.
+
+**에이전트 호환성:** `h3-prompt-writing`은 외부 API 호출이 없는 순수 Markdown + 참조 파일 스킬이므로 Claude Code, Claude Agent SDK, Cursor, Windsurf, OpenAI 기반 에이전트/Codex, LangChain 등 `SKILL.md`와 로컬 파일을 읽을 수 있는 모든 환경에서 동작합니다. 함께 제공되는 `skills/h3-prompt-writing/agents/openai.yaml`은 [OpenAI의 스킬 사양](https://learn.chatgpt.com/docs/build-skills)에 따라 ChatGPT/Codex 스킬 UI를 위한 선택적 UI 메타데이터(표시 이름, 설명, 기본 프롬프트)만 추가할 뿐, 이 스킬을 OpenAI 에이전트로 제한하지 않습니다.
+
+나머지 여덟 개는 MiniMax Hub의 캔버스 워크플로(`hub_generate_video`, `hub_generate_image`, 캔버스 노드, 선택 카드 등)를 위해 만들어진 스타일별 비디오 생성 스킬로, 범용 에이전트 환경으로 이식할 수 없습니다:
 
 <table align="center">
   <tr>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -32,7 +32,11 @@
 npx skills add https://github.com/MiniMax-AI/MiniMax-H3 --skill h3-prompt-writing
 ```
 
-该技能在 `skills/h3-prompt-writing/references/` 下提供两份提示词指南：`base-en.txt` 用于文本/关键帧模式，`ref-en.txt` 用于全参考（Ref2VA）模式。其余八个是面向特定风格的视频生成技能：
+该技能在 `skills/h3-prompt-writing/references/` 下提供两份提示词指南：`base-en.txt` 用于文本/关键帧模式，`ref-en.txt` 用于全参考（Ref2VA）模式。
+
+**智能体兼容性：** `h3-prompt-writing` 是一个纯 Markdown + 参考文件技能，不调用任何外部 API，因此可在 Claude Code、Claude Agent SDK、Cursor、Windsurf、基于 OpenAI 的智能体/Codex、LangChain，以及任何能够读取 `SKILL.md` 和本地文件的运行环境中使用。内置的 `skills/h3-prompt-writing/agents/openai.yaml` 仅按照 [OpenAI 的技能规范](https://learn.chatgpt.com/docs/build-skills) 提供可选的 ChatGPT/Codex 界面元数据（显示名称、描述、默认提示词），并不会将该技能限制为仅适用于 OpenAI 智能体。
+
+其余八个是面向 MiniMax Hub 画布工作流（`hub_generate_video`、`hub_generate_image`、画布节点、选择卡片等）构建的特定风格视频生成技能，无法移植到通用智能体运行环境：
 
 <table align="center">
   <tr>

--- a/skills/3d-animation-short-generator/SKILL.md
+++ b/skills/3d-animation-short-generator/SKILL.md
@@ -2,6 +2,7 @@
 name: 3d-animation-short-generator
 description: |
   Create complete stylized 3D animated shorts from a story idea through an ordered production workflow covering project brief, story outline, character and environment cards, standardized shot planning, text or optional pencil storyboards, video-model selection, single-shot generation, assembly, BGM matching, and final review. Use when the user wants an end-to-end narrative animation workflow with strong character consistency, scene continuity, timing, camera, performance, and audio control. Not for single images, simple edits, photorealistic live action, or one standalone clip.
+compatibility: Requires the MiniMax Hub agent (canvas workspace, choice cards, and hub_generate_image/hub_generate_video tools); not portable to generic agent harnesses.
 ---
 
 # 3D Animation Short Generator

--- a/skills/brand-promo-video-generator/SKILL.md
+++ b/skills/brand-promo-video-generator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: brand-promo-video-generator
 description: For marketers and creators producing promotional content for brands, products, websites, apps, shops, or personal projects. Users provide logos, product images, interface screenshots, official links, or other verifiable assets and confirm duration, aspect ratio, audience, and campaign focus. The Skill organizes brand facts and asset provenance, selects a narrative direction, plans precise beats and shots, generates needed imagery, video, voiceover, or music, and completes assembly and pre-delivery review. It outputs a promotional short that highlights product capabilities, use cases, and a call to action. Best for launches, website showcases, and social promotion; not for imitating real brand marks without authorized assets, inventing product claims, or producing long-form narrative films.
+compatibility: Requires the MiniMax Hub agent (canvas workspace and the hub_* tools listed below); not portable to generic agent harnesses.
 allowed-tools:
 - webfetch
 - hub_image_search

--- a/skills/co-op-game-intro-generator/SKILL.md
+++ b/skills/co-op-game-intro-generator/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: co-op-game-intro-generator
 description: For users creating a two-player co-op game menu or opening animation. Users provide two player names, a game title, a target visual style, and optional character reference images. The Skill locks identity cues, generates an approval image from a fixed menu framework with coordinated color, buttons, icons, and typography, then uses the approved result to rebuild the character, UI-copy, and event timing instructions for the final video. It outputs a co-op game intro featuring two characters, player cards, and menu interaction motion. Best for game concepts, character-led menus, and social content; not for playable game development, complex multi-page UI, exact brand-logo replication, or generic character-free title sequences.
+compatibility: Requires the MiniMax Hub agent (canvas workspace and MiniMax H3 generation); not portable to generic agent harnesses.
 ---
 
 # Co-op Game Intro Generator

--- a/skills/handdrawn-live-video-generator/SKILL.md
+++ b/skills/handdrawn-live-video-generator/SKILL.md
@@ -2,6 +2,7 @@
 name: handdrawn-live-video-generator
 description: |
   For creators making surreal short videos that blend rough glowing hand-drawn animation with live-action spaces. Users provide a scene idea, contact object or hand, desired mood, and optional language or style constraints. The Skill clarifies the physical contact, designs continuous morphing, escape route, and delayed handheld chase movement, then writes a reusable 15-second 16:9 video prompt in the user's language. After user confirmation it recommends MiniMax H3 generation and checks contact realism, camera delay, rough glowing stroke texture, and non-horror tone. Best for single-scene creative clips, not polished CG, horror jump scares, plush characters, or multi-scene cuts.
+compatibility: Requires the MiniMax Hub agent (canvas workspace and MiniMax H3 generation); not portable to generic agent harnesses.
 trigger-words: [手绘发光动画实拍融合, 15秒变形追逐视频提示词, Seedance视频prompt, H3生成视频, 视频prompt, 手绘动画接触真实物体, 蜡笔粉笔质感, 多语言视频提示词]
 ---
 

--- a/skills/minimalist-product-ad-generator/SKILL.md
+++ b/skills/minimalist-product-ad-generator/SKILL.md
@@ -2,6 +2,7 @@
 name: minimalist-product-ad-generator
 description: |
   Turn product images and ad requirements into minimalist product ad shorts for e-commerce promotion and product launches. The Skill confirms format and product variants, extracts selling points, writes concise English ad copy, builds product anchors, plans beat-synced typography/storyboards, and generates a clean product film with premium camera language. Not for KOC talking-head ads, general editing, or complex screen demos.
+compatibility: Requires the MiniMax Hub agent (canvas workspace and MiniMax H3 generation); not portable to generic agent harnesses.
 metadata:
   trigger-words: [minimalist product ad, premium product ad, minimalist product film, 极简产品广告, 高质感产品广告, 产品广告片, 电商产品视频, 新品发布广告]
 ---

--- a/skills/music-video-subtitle-generator/SKILL.md
+++ b/skills/music-video-subtitle-generator/SKILL.md
@@ -2,6 +2,7 @@
 name: music-video-subtitle-generator
 description: |
   For musicians, video creators, and social-media editors producing AI music videos or emotional short films with lyric typography. Users provide music, lyrics, references, characters, typography direction, mood, or target platform. The Skill analyzes beat and vocal timing, separates character, scene, and text references, designs beat-reactive spatial typography, decomposes long works into connected shots, audits prompts, and routes generation for H3 or other video tools. It outputs MV concepts, shot prompts, lyric text plans, and stitching guidance. Best for stylized MVs and subtitle-driven music visuals, not ordinary caption cleanup, licensed IP copying, or fully manual post-production editing.
+compatibility: Requires the MiniMax Hub agent (canvas workspace and Hub generation/routing tools); not portable to generic agent harnesses.
 trigger-words: [MV, music video, lyric typography, on-screen text, prompt audit, Trap MV, Gospel hip-hop, Dark-pop, Cyber-grunge, MV提示词, 歌词文字, 字幕MV, 贴字MV, 卡点MV, 多镜头拼接]
 ---
 

--- a/skills/paper-collage-explainer-generator/SKILL.md
+++ b/skills/paper-collage-explainer-generator/SKILL.md
@@ -2,6 +2,7 @@
 name: paper-collage-explainer-generator
 description: |
   For creators, educators, and social-video editors who need a tactile paper-collage language for narration, knowledge points, opinions, or abstract topics. Users provide source copy, story beats, or a core concept and may specify aspect ratio, duration, palette, and audio needs. The Skill extracts meaning, proposes visual metaphors, prepares a production plan and storyboard, generates approved halftone collage stills, then creates stop-motion clips with paper movement and tactile sound effects, with optional final assembly. By default it keeps collage SFX and does not add BGM, voiceover, or subtitles unless requested. Best for explainers, viewpoints, story visuals, and social B-roll; not for presenter ads, editable layers, complex typography, or prompt-only tasks.
+compatibility: Requires the MiniMax Hub agent (canvas workspace and Hub-native image/video/audio tools); not portable to generic agent harnesses.
 trigger-words: [paper collage explainer, paper-collage animation, halftone collage, collage explainer, 纸拼贴, 拼贴科普, 定格拼贴, 拼贴动画]
 exported-by: MiniMax-hub
 ---

--- a/skills/papercraft-stop-motion-explainer/SKILL.md
+++ b/skills/papercraft-stop-motion-explainer/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: papercraft-stop-motion-explainer
 description: For creators explaining science, education, or general knowledge through tactile handmade papercraft visuals. Users provide a topic, core knowledge points, or source material and may specify audience, duration, aspect ratio, and deliverable type. The Skill extracts the learning goal and visual metaphor, proposes creative directions, designs paper characters, layered diorama sets, and props, creates preview concepts plus image and video prompts, and plans storyboards, camera movement, transitions, and sound with staged approvals and review checklists. It outputs a production-ready papercraft stop-motion explainer package, or selected assets such as still prompts, image-series prompts, short-video prompts, or storyboards. Best for cut-paper, pop-up-book, layered diorama, and miniature stop-motion explainers; not for standard 2D cartoons, line doodles, live action, or explainers without a paper-art look.
+compatibility: Requires the MiniMax Hub agent (canvas workspace and MiniMax H3 generation); not portable to generic agent harnesses.
 ---
 
 # Papercraft Stop-Motion Explainer


### PR DESCRIPTION
## Summary
Follow-up to #13.
- Add a `compatibility` field to the 8 Hub-native skills (`3d-animation-short-generator`, `brand-promo-video-generator`, `co-op-game-intro-generator`, `handdrawn-live-video-generator`, `minimalist-product-ad-generator`, `music-video-subtitle-generator`, `paper-collage-explainer-generator`, `papercraft-stop-motion-explainer`) noting they require the MiniMax Hub agent (canvas workspace, `hub_*` tools) and are not portable to generic agent harnesses — same treatment already given to `h3-prompt-writing`.
- Port the English "Agent compatibility" note added to `README.md` in #13 to `README.zh-CN.md`, `README.ja.md`, and `README.ko.md` so all four READMEs stay in sync.

## Test plan
- [x] Confirmed each `compatibility` string is grounded in that skill's actual body content (canvas nodes, `hub_*` tool references) rather than copied boilerplate.
- [x] Docs-only change; no code paths affected.
- [x] Frontmatter remains valid YAML in all 8 edited `SKILL.md` files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/MiniMax-H3/pr/22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788953298&installation_model_id=427615&pr_number=22&repository=MiniMax-AI%2FMiniMax-H3&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2FMiniMax-H3%2Fpull%2F22&signature=034cda0eb0bb917501c5debd0968bf0c2452e4e50484ad7acb6b07f33843cf09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->