### PR TITLE
docs: fix logical issue in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ The following three use cases T2VA, FL2VA, and Ref2VA demonstrate how to reprodu
 | FL2VA | [View script](scripts/readme/reproducible-768p-fl2va-request.sh) | [fl2va.mp4](assets/fl2va.mp4) |
 | Ref2VA | [View script](scripts/readme/reproducible-768p-ref2va-request.sh) | [ref2va.mp4](assets/ref2va.mp4) |
 
-### Full 2K\-Workflow
+### Full 2K Workflow
 
 This section explains how to combine a locally deployed SGLang service with the official **H3\-Context\-IR** and **H3\-Regenerate\-2K** APIs to reproduce the quality of 2K videos generated directly by the MiniMax API\.
 Before you begin, configure the SGLang endpoint and your MiniMax API credentials:


### PR DESCRIPTION
## Problem

The section heading uses a hyphen between '2K' and 'Workflow' ('Full 2K-Workflow'), but the body text consistently refers to it without the hyphen as 'Full 2K Workflow' (lines 106, 178, 170). Inconsistent terminology for the same section name.

This is a documentation-only fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/MiniMax-H3/pr/35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789017963&installation_model_id=427615&pr_number=35&repository=MiniMax-AI%2FMiniMax-H3&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2FMiniMax-H3%2Fpull%2F35&signature=69c6b8af60102404fa3577fee05056c4b4165a9aa3a0dcad386c97918148ec4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->