### PR TITLE
docs: clarify local image support in conditions.uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,28 @@ The following three use cases T2VA, FL2VA, and Ref2VA demonstrate how to reprodu
 | FL2VA | [View script](scripts/readme/reproducible-768p-fl2va-request.sh) | [fl2va.mp4](assets/fl2va.mp4) |
 | Ref2VA | [View script](scripts/readme/reproducible-768p-ref2va-request.sh) | [ref2va.mp4](assets/ref2va.mp4) |
 
+#### Using a local image/video instead of a remote URL
+
+The reproducible scripts above reference `conditions[].uri` values hosted on a public CDN so they work out of the box, but `uri` is not limited to `http(s)://`. For local testing you can point it at a `file://` path instead — for example, to swap the FL2VA keyframe for your own image:
+
+```json
+"conditions": [
+  {
+    "type": "image",
+    "uri": "file:///data/minimax-h3/my-keyframe.png",
+    "role": "keyframe",
+    "frame_index": 0
+  }
+]
+```
+
+The path is resolved by the SGLang server process, not by the machine running `curl`, so it must point to a file the server can actually see:
+
+- If `sglang serve` runs natively on the host, any absolute path readable by that process works.
+- If it runs in a container, the file must live inside a directory you mounted into the container (e.g. mount a host folder to `/data/minimax-h3` and reference `file:///data/minimax-h3/...`).
+
+See the [MiniMax-H3 SGLang cookbook](https://docs.sglang.io/cookbook/diffusion/MiniMax/MiniMax-H3) for the full list of supported condition/media options.
+
 ### Full 2K Workflow
 
 This section explains how to combine a locally deployed SGLang service with the official **H3\-Context\-IR** and **H3\-Regenerate\-2K** APIs to reproduce the quality of 2K videos generated directly by the MiniMax API\.


### PR DESCRIPTION
## Summary

Document support for local images in `conditions[].uri` for FL2VA examples.

## Motivation

Issue #40 asks whether the image URL can be replaced with a local image for testing. The current README only demonstrates remote CDN URLs, while the SGLang MiniMax-H3 deployment also supports `file://` URIs.

## Changes

- Added a note explaining that `file://` URIs are supported.
- Included an example using a local keyframe image.
- Clarified that the path is resolved by the SGLang server process.
- Linked to the SGLang cookbook for more details.

Fixes #40

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/MiniMax-H3/pr/45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789065056&installation_model_id=427615&pr_number=45&repository=MiniMax-AI%2FMiniMax-H3&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2FMiniMax-H3%2Fpull%2F45&signature=86e308f65fd7471b7c0e0db787613b9413a87a2c9935f3566e5c8e32575de639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->