### PR TITLE
Add skill: h3-character-eval — calibrated character-retention measurement

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,6 +1,6 @@
 # MiniMax H3 Skills
 
-This directory contains the skills bundled with [MiniMax H3](../README.md): **1 prompt writing skill** and **8 style-specific video generation skills**. Each skill lives in its own folder with an installable `SKILL.md` (plus a `SKILL.cn.md` Chinese version for the style skills) and any reference materials it needs.
+This directory contains the skills bundled with [MiniMax H3](../README.md): **1 prompt writing skill**, **8 style-specific video generation skills**, and **1 evaluation skill**. Each skill lives in its own folder with an installable `SKILL.md` (plus a `SKILL.cn.md` Chinese version for the style skills) and any reference materials it needs.
 
 ## Status
 
@@ -31,6 +31,12 @@ Write structured MiniMax H3 video generation prompts for all five generation mod
 
 - [`base-en.txt`](h3-prompt-writing/references/base-en.txt) — base text/keyframe modes
 - [`ref-en.txt`](h3-prompt-writing/references/ref-en.txt) — full-reference (Ref2VA) mode
+
+### h3-character-eval
+
+Measure whether generated videos preserved a character's declared visual traits — the contract Ref2VA `retention_analysis` asserts but nothing measures. Builds a binary, style-invariant trait contract from character cards, renders a fixed scenario via reference-to-video, and audits sampled frames with a vision model under three calibration controls (card positive control, two-pass stability with majority tie-breaks, hard-negative specificity). Outputs a promised-vs-delivered scorecard in the retention-marker vocabulary, per-trait failures by cell, and a sign test for arm comparisons. English-only. The judge prompt and control arithmetic live under [`references/`](h3-character-eval/references/eval-protocol.md).
+
+[SKILL.md](h3-character-eval/SKILL.md)
 
 ### minimalist-product-ad-generator
 

--- a/skills/h3-character-eval/SKILL.md
+++ b/skills/h3-character-eval/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: h3-character-eval
+description: Measure whether generated videos preserved a character's declared visual traits — the contract Ref2VA retention_analysis asserts. Use when comparing styles, prompts, models, or skill versions on character consistency; when validating a character card before production use; or when a subjective "the character drifted" needs a number. Builds a trait contract from the character card, renders via reference-to-video, audits frames with a vision model under three calibration controls (positive control, two-pass stability, hard negatives), and reports pass rates in the retention-marker vocabulary (fully_preserved / partially_preserved / weak_reference).
+compatibility: Portable to any agent that can call the MiniMax video generation API (or MiniMax Hub video tools), call a vision-capable chat model (e.g. MiniMax-M3), and extract video frames (ffmpeg). No other external services.
+---
+
+# H3 Character Retention Eval
+
+Every Ref2VA prompt promises per-subject retention (`fully_preserved`, ...) and
+the style skills name the failure modes — identity swap, face fusion, trait
+drift — but nothing in the toolchain measures whether a delivered video honored
+the promise. This skill is that measurement. Its design was validated end to
+end on an 8-character × 3-style × 2-model grid (144 renders): the calibration
+controls below caught unrendered promises, vision-judge misses, and
+badly-authored traits before any of them could pollute a score, reaching judge
+stability 0.992 and specificity 1.000. Method details, the judge prompt, and
+the pitfalls live in [`references/eval-protocol.md`](references/eval-protocol.md).
+
+Core idea: **score the model against its own contract.** Traits are declared
+from the character card, the render is asked to preserve them, and a vision
+judge checks each trait in sampled frames — with controls that measure the
+judge itself, because an uncalibrated judge produces confident nonsense.
+
+## STEP 1 — Author the trait contract
+
+For each character, write 4–6 traits from its reference card. Every trait must
+be:
+
+- **Binary and visually checkable in a single frame** ("red collar", "black
+  patch surrounding one eye") — never a vibe ("cute", "consistent").
+- **Style-invariant identity content** — markings, colors, accessories,
+  asymmetries. Never rendering style ("oversized cartoon eyes" *correctly*
+  disappears in a photoreal restyle and would score as a false failure).
+- **Distinctive against a confusable character** — "white chest patch" is true
+  of half of all dogs and will leak in the negative control; compound the
+  feature with color/species context until it discriminates.
+
+Multi-character scenes get **binding traits** instead of appearance traits:
+"the red collar is worn by the dog, not the cat", "exactly two animals",
+"clearly different body shapes, not blended" — swap and fusion only exist with
+two or more subjects.
+
+## STEP 2 — Positive control: audit the card itself
+
+Before rendering anything, run the vision judge on the character card against
+its own trait list (protocol in the reference file). A trait the card does not
+clearly show is **not checkable** — the image model that made the card may not
+have rendered it, or the wording may be falsified by the card (a "solid black
+coat" with a white chest patch). Drop non-present traits from all scoring.
+Scoring a video against a promise the card never made is noise.
+
+## STEP 3 — Render the grid
+
+Render each character through reference-to-video (`role: reference_image`,
+the card(s) as references) with a **fixed scenario** across every arm so the
+variable under test (style, prompt, model, skill version) is the only thing
+that changes. Always include the identity-anchor clause: references are for
+identity mapping only — preserve every listed marking, color, and accessory;
+restyle the rendering, never the anchors. Use **n≥3 renders per cell** for any
+claim beyond screening; a single render confounds render variance with a real
+effect.
+
+## STEP 4 — Two-pass audit with tie-breaks
+
+For each video, sample 5 frames at spread timestamps and ask the vision judge
+for a strict-JSON verdict per trait: `present` / `absent` / `unsure` (exact
+prompt in the reference file; temperature 0). Then judge the **same video
+again on a disjoint frame sample**. Where the two passes disagree on any
+trait, judge a third disjoint sample and take the per-trait majority; no
+majority means `unsure`. `unsure` counts as a failure but is tallied
+separately.
+
+## STEP 5 — Calibrate the judge, always
+
+Report these next to every headline number — they are what make it readable:
+
+- **Stability** = agreement rate between pass A and pass B over checkable
+  traits. Any gap between arms smaller than (1 − stability) is judge noise,
+  not a finding. In validation this control caught the run's only two
+  apparent failures as judge misses.
+- **Specificity** = 1 − leak rate when each video is judged against a
+  *different, confusable* character's traits (same species where possible;
+  never a character that appears in the video). Foreign traits should come
+  back `absent`; leaks mean the traits are too generic to trust.
+
+## STEP 6 — Scorecard in the retention vocabulary
+
+A cell's score is its mean trait-pass rate over checkable traits and reps.
+Map it onto the markers the Ref2VA contract uses: ≥0.9 `fully_preserved`,
+≥0.5 `partially_preserved`, else `weak_reference` — and present it as
+**promised vs delivered** (the promise is `fully_preserved` everywhere). For
+arm comparisons, use a sign test over the paired per-cell differences rather
+than eyeballing means. List every failed trait by cell: "which trait, which
+style" is the actionable output, not the aggregate.

--- a/skills/h3-character-eval/meta.yaml
+++ b/skills/h3-character-eval/meta.yaml
@@ -1,0 +1,17 @@
+display-name-zh: 角色一致性评测
+version: 0.1.0
+tag-en: Evaluation
+tag-cn: 评测
+complete-tags-en:
+- Evaluation / Character Consistency
+- Evaluation / Quality Control
+complete-tags-cn:
+- 评测 / 角色一致性
+- 评测 / 质量控制
+summary-en: Measure whether generated videos preserved a character's declared traits, with a calibrated vision-judge audit.
+summary-cn: 用带校准控制的视觉模型审计，量化生成视频对角色既定特征的保持程度，输出 retention 词汇表评分。
+desc-en: For creators and developers who need character consistency as a number instead of a feeling. You provide character reference cards; the skill authors a binary, style-invariant trait contract from each card, prunes traits the card itself never rendered (positive control), renders a fixed scenario through reference-to-video, and audits sampled frames with a vision model under two further controls — two-pass stability with majority tie-breaks, and hard-negative specificity against confusable characters. Results map onto the Ref2VA retention vocabulary (fully_preserved / partially_preserved / weak_reference) as a promised-vs-delivered scorecard, with per-trait failures listed by cell and a sign test for arm comparisons. Validated on an 8-character, 3-style, 2-model grid (144 renders) where the controls caught unrendered promises, judge misses, and over-generic traits. Best for comparing styles, prompts, models, or skill versions on character retention; not a general video-quality or motion-quality benchmark.
+desc-cn: 面向需要把「角色一致性」从感觉变成数字的创作者与开发者。用户提供角色参考卡；本 Skill 会从卡片提炼可单帧核验、风格无关的二元特征契约，先用正向对照剔除卡片本身未呈现的特征，再以固定情景通过 reference-to-video 生成视频，并用视觉模型对采样帧逐特征审计，辅以两道校准控制：双轮稳定性（分歧走第三轮多数裁决）与易混角色硬负例特异性。结果映射到 Ref2VA retention 词汇表（fully_preserved / partially_preserved / weak_reference），输出「承诺 vs 交付」评分卡、逐格失败特征清单，以及用于组间比较的符号检验。已在 8 角色 × 3 风格 × 2 模型（144 次生成）网格上验证，三道控制分别捕获了未渲染的承诺、评审误判与过于泛化的特征。适用于比较风格、提示词、模型或 Skill 版本的角色保持能力；不适用于整体画质或运动质量评测。
+author-en: Billy Zhao
+author-cn: Billy Zhao
+source: community

--- a/skills/h3-character-eval/references/eval-protocol.md
+++ b/skills/h3-character-eval/references/eval-protocol.md
@@ -1,0 +1,96 @@
+# Eval protocol — judge prompt, controls, and pitfalls
+
+This is the measurement layer behind `SKILL.md`, with the exact judge prompt
+and the arithmetic. Everything here was validated on a real grid: 8 characters
+(dog / cat / bird / exotic; photo / cartoon / 3D-render source cards; one
+two-subject binding row) × 3 target styles (photoreal, Pixar-style 3D,
+hand-drawn) × 2 video models × 3 replicates — 144 renders, 316 judge calls.
+
+## The judge prompt
+
+Send the sampled frames plus this text to a vision-capable chat model at
+temperature 0 (validation used MiniMax-M3; strip any thinking block before
+parsing):
+
+```
+You are auditing whether a generated video preserved a character's declared
+visual traits. The attached images are frames sampled from one video. For each
+numbered trait, answer:
+- "present": the trait is clearly visible in at least one frame
+- "absent": the subject is visible but the trait is missing, changed, or on
+the wrong individual
+- "unsure": the frames do not let you tell
+
+The video may be stylized (cartoon, 3D, hand-drawn): judge the trait's identity
+content (marking, color, accessory, asymmetry), not its rendering style.
+
+Traits:
+{numbered trait list}
+
+Reply with ONLY a JSON object mapping each trait number to its verdict, e.g.
+{"1": "present", "2": "absent"}. No other text.
+```
+
+Frame samples (fractions of the clip's duration):
+
+- pass A: 0.02, 0.25, 0.50, 0.75, 0.97
+- pass B: 0.12, 0.37, 0.62, 0.87, 0.90
+- tie-break pass C (only where A and B disagree): 0.06, 0.30, 0.55, 0.80, 0.94
+
+Per-trait verdict: A if A==B, else the majority of {A, B, C}; no majority →
+`unsure`. `unsure` fails the trait but is tallied separately from `absent`.
+
+## The three controls, and why each exists
+
+**1. Positive control (card audit) — defines the checkable set.** Judge each
+card against its own traits before any video is scored; drop traits not
+`present`. Two distinct causes show up in practice: the card's image model
+did not render a requested detail (asymmetric ears, a leg band, a paw
+marking), and trait wording the card itself falsifies (a "solid black coat"
+on a card with a white chest patch). In validation this pruned 6/42 traits on
+the first pass and 1/35 after traits were re-authored against the cards.
+
+**2. Two-pass stability — measures the judge.** Stability = per-trait
+agreement between passes A and B across all videos. Report it with every
+result and refuse to read any arm-vs-arm gap smaller than (1 − stability). In
+validation the run's only two apparent retention failures sat exactly on A/B
+disagreements — human frame inspection confirmed the traits were present, so
+the "failures" were judge misses the control had already flagged. Stability
+was 0.969 with loosely-authored traits and 0.992 after the re-authoring.
+
+**3. Hard-negative specificity — measures the traits.** Judge each video once
+against a *different* character's trait list and expect `absent` everywhere.
+Two rules learned the hard way: pick a **confusable** foreign character (same
+species where possible — corgi↔pug, black cat↔ginger tabby), and **never one
+whose subject appears in the video** (a two-character video judged against
+one of its own members "leaks" its genuine traits and reads as a false
+failure of the control). Leaked traits are too generic — rewrite them with
+color/species context until they discriminate. Validation: 0.769 specificity
+with generic traits and an overlapping pairing; 1.000 after both fixes.
+
+## Scoring
+
+- Cell = one character × one arm (style/model/prompt variant). Cell score =
+  mean over replicates of (traits `present` ÷ checkable traits), pass-A/B/C
+  verdicts as above.
+- Markers: ≥0.9 `fully_preserved`, ≥0.5 `partially_preserved`, else
+  `weak_reference`. The promise is `fully_preserved` everywhere — report
+  promised vs delivered.
+- Arm comparison: exact two-sided sign test over the paired per-cell
+  differences (ties dropped). Means without the sign test overstate small
+  grids.
+- Always list failed traits by cell. "The crest drops in stylized restyles of
+  birds" is actionable; "0.97 overall" is not.
+
+## Pitfalls checklist
+
+- A trait the card doesn't show scores the card generator, not the video
+  model — that's what the positive control removes.
+- Style traits ("oversized cartoon eyes") fail *correctly* under restyling
+  and poison the score — identity content only.
+- n=1 per cell confounds render variance with real effects: in validation,
+  every sub-1.0 cell at n=3 had two perfect sibling replicates.
+- Sub-second single-frame checks miss traits that flicker; "present in at
+  least one frame" over 5 spread frames is deliberate.
+- If the judge and the generator share a vendor, the controls are the
+  mitigation, not brand independence — say so when reporting.


### PR DESCRIPTION
## What

A new community skill, `h3-character-eval`, that measures the promise the existing toolchain makes but never checks: Ref2VA prompts assert per-subject `retention_analysis` markers, and the style skills name the failure modes (identity swap, face fusion, trait drift) — this skill turns "did the character survive?" into a calibrated number.

**Method** (SKILL.md + `references/eval-protocol.md`): author a binary, style-invariant trait contract from each character card; prune traits the card itself never rendered (positive control); render a fixed scenario via reference-to-video; audit sampled frames with a vision model (exact judge prompt included, strict JSON, temperature 0) under two further controls — two-pass frame-sample stability with majority tie-breaks, and hard-negative specificity against confusable characters. Scores map onto the retention-marker vocabulary (`fully_preserved` / `partially_preserved` / `weak_reference`) as a promised-vs-delivered scorecard, with per-trait failures listed by cell and an exact sign test for arm comparisons.

## Why the controls are the point

We validated the protocol on an 8-character × 3-style × 2-model grid (144 renders, 316 judge calls, n=3 replicates). Each control caught a real problem class before it could pollute a score:

- the positive control pruned traits the card generator never rendered (6/42 on the first authoring pass);
- the stability control flagged the run's only two apparent retention failures as vision-judge misses (confirmed by human frame inspection);
- the hard-negative control exposed over-generic traits and a subject-overlap flaw in our own first derangement.

After the fixes the judge measured 0.992 stability and 1.000 specificity — and H3 held `fully_preserved` across photoreal / Pixar-3D / hand-drawn restyling on the whole roster, including a two-subject binding row (no swap, no fusion).

## Files

- `skills/h3-character-eval/SKILL.md` — the workflow (portable: video API + a vision chat model + ffmpeg)
- `skills/h3-character-eval/meta.yaml` — bilingual metadata, `source: community`
- `skills/h3-character-eval/references/eval-protocol.md` — judge prompt, control arithmetic, pitfalls checklist
- `skills/README.md` — index entry

English-only for now (same status as `h3-prompt-writing`); happy to add a `SKILL.cn.md` if maintainers want it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MiniMax-AI/codesmith/MiniMax-H3/pr/67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790237213&installation_model_id=427615&pr_number=67&repository=MiniMax-AI%2FMiniMax-H3&return_to=https%3A%2F%2Fgithub.com%2FMiniMax-AI%2FMiniMax-H3%2Fpull%2F67&signature=1e119a74651967ae8a271a21b6bad781bab1c85b553c79e394d868a2359defe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->